### PR TITLE
Replace chrono with std::time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,21 +46,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "android-tzdata"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
-
-[[package]]
-name = "android_system_properties"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -110,12 +95,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bumpalo"
-version = "3.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
-
-[[package]]
 name = "cc"
 version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -126,24 +105,6 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
-name = "chrono"
-version = "0.4.38"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
-dependencies = [
- "android-tzdata",
- "iana-time-zone",
- "num-traits",
- "windows-targets",
-]
-
-[[package]]
-name = "core-foundation-sys"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
 name = "cpufeatures"
@@ -389,29 +350,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "iana-time-zone"
-version = "0.1.60"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
-dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "iana-time-zone-haiku",
- "js-sys",
- "wasm-bindgen",
- "windows-core",
-]
-
-[[package]]
-name = "iana-time-zone-haiku"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "idna"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -426,15 +364,6 @@ name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
-
-[[package]]
-name = "js-sys"
-version = "0.3.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
-dependencies = [
- "wasm-bindgen",
-]
 
 [[package]]
 name = "lexopt"
@@ -517,7 +446,6 @@ version = "1.0.0"
 dependencies = [
  "addr",
  "anyhow",
- "chrono",
  "fastrand",
  "flate2",
  "lexopt",
@@ -545,15 +473,6 @@ dependencies = [
  "cfg-if",
  "libc",
  "memoffset",
-]
-
-[[package]]
-name = "num-traits"
-version = "0.2.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
-dependencies = [
- "autocfg",
 ]
 
 [[package]]
@@ -990,73 +909,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
-name = "wasm-bindgen"
-version = "0.2.92"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
-dependencies = [
- "cfg-if",
- "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.92"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
-dependencies = [
- "bumpalo",
- "log",
- "once_cell",
- "proc-macro2",
- "quote",
- "syn",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-macro"
-version = "0.2.92"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
-dependencies = [
- "quote",
- "wasm-bindgen-macro-support",
-]
-
-[[package]]
-name = "wasm-bindgen-macro-support"
-version = "0.2.92"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "wasm-bindgen-backend",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-shared"
-version = "0.2.92"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
-
-[[package]]
 name = "webpki-roots"
 version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
-
-[[package]]
-name = "windows-core"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
-dependencies = [
- "windows-targets",
-]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,6 @@ license = " AGPL-3.0-or-later"
 
 [dependencies]
 anyhow = { version = "1", default-features = false, features = [ "std" ] }
-chrono = { version = "0.4", default-features = false, features = [ "alloc", "std", "clock" ] }
 fastrand = { version = "2", default-features = false, features = [ "std" ] }
 lexopt = { version = "0.3", default-features = false }
 ureq = { version = "2", default-features = false, features = [ "tls", "gzip", "brotli", "json" ] }

--- a/src/db.rs
+++ b/src/db.rs
@@ -69,7 +69,9 @@ struct UnixTimestamp(SystemTime);
 
 impl ToSql for UnixTimestamp {
     fn to_sql(&self) -> rusqlite::Result<ToSqlOutput<'_>> {
-        let duration_since_epoch = self.0.duration_since(UNIX_EPOCH)
+        let duration_since_epoch = self
+            .0
+            .duration_since(UNIX_EPOCH)
             .map_err(|e| FromSqlError::OutOfRange(e.duration().as_secs() as i64))?;
         Ok(ToSqlOutput::from(duration_since_epoch.as_secs() as i64))
     }
@@ -79,10 +81,12 @@ impl FromSql for UnixTimestamp {
     fn column_result(value: ValueRef<'_>) -> FromSqlResult<Self> {
         let t = value.as_i64()?;
         let t = if t >= 0 {
-            UNIX_EPOCH.checked_add(Duration::from_secs(t as u64))
+            UNIX_EPOCH
+                .checked_add(Duration::from_secs(t as u64))
                 .ok_or_else(|| FromSqlError::OutOfRange(t))?
         } else {
-            UNIX_EPOCH.checked_sub(Duration::from_secs(t.unsigned_abs()))
+            UNIX_EPOCH
+                .checked_sub(Duration::from_secs(t.unsigned_abs()))
                 .ok_or_else(|| FromSqlError::OutOfRange(t))?
         };
         Ok(UnixTimestamp(t))

--- a/src/time.rs
+++ b/src/time.rs
@@ -45,7 +45,6 @@
 //! won't all get scheduled onto the same time. The amount of randomness is bigger than with the
 //! other two functions; it's any number of seconds from 0 to 29 hours (both inclusive).
 use anyhow::anyhow;
-use chrono::{DateTime, Utc};
 use std::ops::{RangeBounds, RangeInclusive};
 use std::time::{Duration, SystemTime};
 
@@ -54,7 +53,7 @@ const DAY_HOURS_IN_SECONDS: u64 = 29 * 3600;
 fn now_plus_offset_plus_random_from_range(
     fixed_offset: Duration,
     range: impl RangeBounds<i64>,
-) -> anyhow::Result<DateTime<Utc>> {
+) -> anyhow::Result<SystemTime> {
     let random_offset = fastrand::i64(range);
 
     let final_offset_seconds = fixed_offset
@@ -76,14 +75,11 @@ fn now_plus_offset_plus_random_from_range(
         )
     })?;
 
-    // Convert SystemTime to chrono::DateTime<Utc>
-    let datetime: DateTime<Utc> = final_time.into();
-
-    Ok(datetime)
+    Ok(final_time)
 }
 
 /// Random datetime about a day from now (now + 29 hours ± 2 hours).
-pub fn about_a_day_from_now() -> anyhow::Result<DateTime<Utc>> {
+pub fn about_a_day_from_now() -> anyhow::Result<SystemTime> {
     const TWO_HOURS_SECS: i64 = 2 * 60 * 60;
     const RAND_RANGE: RangeInclusive<i64> = -TWO_HOURS_SECS..=TWO_HOURS_SECS;
     let starting_point = Duration::from_secs(DAY_HOURS_IN_SECONDS);
@@ -91,7 +87,7 @@ pub fn about_a_day_from_now() -> anyhow::Result<DateTime<Utc>> {
 }
 
 /// Random datetime about a week away from now (now + 167 hours ± 11.5 hours).
-pub fn about_a_week_from_now() -> anyhow::Result<DateTime<Utc>> {
+pub fn about_a_week_from_now() -> anyhow::Result<SystemTime> {
     const ELEVEN_AND_A_HALF_HOURS_SECS: i64 = (11 * 60 + 30) * 60;
     const RAND_RANGE: RangeInclusive<i64> =
         -ELEVEN_AND_A_HALF_HOURS_SECS..=ELEVEN_AND_A_HALF_HOURS_SECS;
@@ -101,7 +97,7 @@ pub fn about_a_week_from_now() -> anyhow::Result<DateTime<Utc>> {
 }
 
 /// Random datetime no further than 29 hours from now.
-pub fn sometime_today() -> anyhow::Result<DateTime<Utc>> {
+pub fn sometime_today() -> anyhow::Result<SystemTime> {
     now_plus_offset_plus_random_from_range(
         Duration::from_secs(0),
         0..=(DAY_HOURS_IN_SECONDS as i64),
@@ -109,7 +105,7 @@ pub fn sometime_today() -> anyhow::Result<DateTime<Utc>> {
 }
 
 /// Random datetime about 6.1 hours from now (now + 6 hours 6 minutes ± 5 minutes).
-pub fn in_about_six_hours() -> anyhow::Result<DateTime<Utc>> {
+pub fn in_about_six_hours() -> anyhow::Result<SystemTime> {
     const FIVE_MINUTES_SECS: i64 = 5 * 60;
     const SIX_HOURS_SIX_MINUTES_SECS: u64 = (6 * 60 + 6) * 60;
     let six_hours_six_minutes_duration = Duration::from_secs(SIX_HOURS_SIX_MINUTES_SECS);


### PR DESCRIPTION
This commit replaces chrono::Duration with std::time::Duration.
Fix for issue: #294